### PR TITLE
Fix path to installer script

### DIFF
--- a/.github/scripts/install-rcodesign.sh
+++ b/.github/scripts/install-rcodesign.sh
@@ -6,13 +6,12 @@
 set -euo pipefail
 
 # override for testing
-: "${DEST_DIR:=${PWD}/.bob/tools}"
+: "${DEST_DIR:="$(/bin/pwd -P)/.bob/tools"}"
 : "${VERSION:=0.22.0}"
 # defaults for local testing
 : "${RUNNER_TEMP:=/tmp}"
 : "${GITHUB_PATH:=${RUNNER_TEMP}/GITHUB_PATH}"
 
-/usr/bin/env | sort 1>&2
 readonly release="apple-codesign-${VERSION}-x86_64-unknown-linux-musl"
 readonly tag="apple-codesign/$VERSION"
 readonly asset="${release}.tar.gz"
@@ -39,9 +38,8 @@ tar --extract \
 
 ## Add to path if not already present
 if [[ ":$PATH:" != *":${DEST_DIR}:"* ]] ; then
+    echo "Adding [$DEST_DIR] to PATH"
     echo "$DEST_DIR" >> "$GITHUB_PATH"
 fi
 
-echo "$GITHUB_PATH" 1>&2
-cat "$GITHUB_PATH" 1>&2
 exit 1

--- a/.github/scripts/install-rcodesign.sh
+++ b/.github/scripts/install-rcodesign.sh
@@ -12,7 +12,8 @@ set -euo pipefail
 : "${RUNNER_TEMP:=/tmp}"
 : "${GITHUB_PATH:=${RUNNER_TEMP}/GITHUB_PATH}"
 
-readonly release="apple-codesign-${VERSION}-x86_64-unknown-linux-musl"
+readonly release="apple-codesign-${VERSION}-x86_64-unknown-linux-musl" 
+/usr/bin/env | sort
 readonly tag="apple-codesign/$VERSION"
 readonly asset="${release}.tar.gz"
 readonly sums_name="SHA256SUMS"
@@ -40,3 +41,5 @@ tar --extract \
 if [[ ":$PATH:" != *":${DEST_DIR}:"* ]] ; then
     echo "$DEST_DIR" >> "$GITHUB_PATH"
 fi
+
+echo "$GITHUB_PATH"

--- a/.github/scripts/install-rcodesign.sh
+++ b/.github/scripts/install-rcodesign.sh
@@ -12,8 +12,8 @@ set -euo pipefail
 : "${RUNNER_TEMP:=/tmp}"
 : "${GITHUB_PATH:=${RUNNER_TEMP}/GITHUB_PATH}"
 
-readonly release="apple-codesign-${VERSION}-x86_64-unknown-linux-musl" 
-/usr/bin/env | sort
+/usr/bin/env | sort 1>&2
+readonly release="apple-codesign-${VERSION}-x86_64-unknown-linux-musl"
 readonly tag="apple-codesign/$VERSION"
 readonly asset="${release}.tar.gz"
 readonly sums_name="SHA256SUMS"
@@ -42,4 +42,6 @@ if [[ ":$PATH:" != *":${DEST_DIR}:"* ]] ; then
     echo "$DEST_DIR" >> "$GITHUB_PATH"
 fi
 
-echo "$GITHUB_PATH"
+echo "$GITHUB_PATH" 1>&2
+cat "$GITHUB_PATH" 1>&2
+exit 1

--- a/.github/scripts/install-rcodesign.sh
+++ b/.github/scripts/install-rcodesign.sh
@@ -6,7 +6,8 @@
 set -euo pipefail
 
 # override for testing
-: "${DEST_DIR:="$(/bin/pwd -P)/.bob/tools"}"
+#: "${DEST_DIR:="$(/bin/pwd -P)/.bob/tools"}"
+[ -n "$DEST_DIR" ] || DEST_DIR="$(/bin/pwd -P)/.bob/tools"
 : "${VERSION:=0.22.0}"
 # defaults for local testing
 : "${RUNNER_TEMP:=/tmp}"
@@ -42,4 +43,6 @@ if [[ ":$PATH:" != *":${DEST_DIR}:"* ]] ; then
     echo "$DEST_DIR" >> "$GITHUB_PATH"
 fi
 
+echo mark 1
 exit 1
+echo mark 2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ permissions:
 jobs:
   test-install:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dest_dir: [ '', '/tmp/rcodesign' ]
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: Install
@@ -18,15 +21,24 @@ jobs:
         with:
           # needed for installer to run gh tool
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          install-dir: ${{ matrix.dest_dir }}
       - name: Check Default Installation Path
         run: |
-          exp_dir="${PWD}/.bob/tools"
+          case "${{ matrix.dest_dir }}" in
+            '') exp_dir="${PWD}/.bob/tools" ;;
+            *) exp_dir="${{ matrix.dest_dir }}" ;;
+          esac
           if ! grep "$exp_dir" <<< "$PATH" ; then
             echo "Expected $exp_dir in PATH but it's absent." 1>&2
             exit 1
           fi
       - name: Check tool can be run
         run: rcodesign --version
+
+  script-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: Run Shellcheck
         uses: docker://koalaman/shellcheck:stable
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,4 +31,4 @@ jobs:
         uses: docker://koalaman/shellcheck:stable
         with:
           # running the step in a container mounts the workspace as below
-          args: "/github/workspace/.github/scripts/install-rcodesign.sh"
+          args: "/github/workspace/install-rcodesign.sh"

--- a/action.yml
+++ b/action.yml
@@ -29,12 +29,6 @@ runs:
         DEST_DIR: ${{ inputs.install-dir }}
         VERSION: ${{ inputs.version }}
       run: |
-        set -x
-        /usr/bin/env | sort
-        echo ==== before
-        echo "$GITHUB_PATH"
-        cat "$GITHUB_PATH"
-        echo ====
         bash -x .github/scripts/install-rcodesign.sh
         echo "exit status $?"
         echo ==== after
@@ -46,6 +40,10 @@ runs:
       run: |
         set -x
         /usr/bin/env | grep '^PATH='
+    - name: Run the tool
+      shell: bash
+      run: |
+        rcodesign --version
     - name: Abort Abort Abort
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,7 @@ runs:
         DEST_DIR: ${{ inputs.install-dir }}
         VERSION: ${{ inputs.version }}
       run: |
+        bash --version
         bash -x .github/scripts/install-rcodesign.sh
         echo "exit status $?"
         echo ==== after

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,8 @@ runs:
         DEST_DIR: ${{ inputs.install-dir }}
         VERSION: ${{ inputs.version }}
       run: |
-        "${GITHUB_ACTION}/.github/scripts/install-rcodesign.sh"
+        /bin/ls -lR "$GITHUB_ACTION_PATH"
+        "${GITHUB_ACTION_PATH}/.github/scripts/install-rcodesign.sh"
         echo "exit status $?"
         echo ==== after
         echo "$GITHUB_PATH"

--- a/action.yml
+++ b/action.yml
@@ -31,14 +31,16 @@ runs:
       run: |
         set -x
         /usr/bin/env | sort
-        echo ====
-        /bin/ls -l .github/scripts/
-        echo ====
-        .github/scripts/install-rcodesign.sh
-        echo ====
+        echo ==== before
         echo "$GITHUB_PATH"
         cat "$GITHUB_PATH"
         echo ====
+        .github/scripts/install-rcodesign.sh > script-output 2>&1
+        echo ==== after
+        echo "$GITHUB_PATH"
+        cat "$GITHUB_PATH"
+        echo ====
+        cat script-output
     - name: Check New PATH
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -28,24 +28,4 @@ runs:
         GH_TOKEN: ${{ inputs.github-token }}
         DEST_DIR: ${{ inputs.install-dir }}
         VERSION: ${{ inputs.version }}
-      run: |
-        /bin/ls -lR "$GITHUB_ACTION_PATH"
-        "${GITHUB_ACTION_PATH}/install-rcodesign.sh"
-        echo "exit status $?"
-        echo ==== after
-        echo "$GITHUB_PATH"
-        cat "$GITHUB_PATH"
-        echo ====
-    - name: Check New PATH
-      shell: bash
-      run: |
-        set -x
-        /usr/bin/env | grep '^PATH='
-    - name: Run the tool
-      shell: bash
-      run: |
-        rcodesign --version
-    - name: Abort Abort Abort
-      shell: bash
-      run: |
-        exit 1
+      run: "${GITHUB_ACTION_PATH}/install-rcodesign.sh"

--- a/action.yml
+++ b/action.yml
@@ -28,4 +28,23 @@ runs:
         GH_TOKEN: ${{ inputs.github-token }}
         DEST_DIR: ${{ inputs.install-dir }}
         VERSION: ${{ inputs.version }}
-      run: .github/scripts/install-rcodesign.sh
+      run: |
+        set -x
+        /usr/bin/env | sort
+        echo ====
+        /bin/ls -l .github/scripts/
+        echo ====
+        .github/scripts/install-rcodesign.sh
+        echo ====
+        echo "$GITHUB_PATH"
+        cat "$GITHUB_PATH"
+        echo ====
+    - name: Check New PATH
+      shell: bash
+      run: |
+        set -x
+        /usr/bin/env | grep '^PATH='
+    - name: Abort Abort Abort
+      shell: bash
+      run: |
+        exit 1

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ runs:
         VERSION: ${{ inputs.version }}
       run: |
         /bin/ls -lR "$GITHUB_ACTION_PATH"
-        "${GITHUB_ACTION_PATH}/.github/scripts/install-rcodesign.sh"
+        "${GITHUB_ACTION_PATH}/install-rcodesign.sh"
         echo "exit status $?"
         echo ==== after
         echo "$GITHUB_PATH"

--- a/action.yml
+++ b/action.yml
@@ -35,14 +35,12 @@ runs:
         echo "$GITHUB_PATH"
         cat "$GITHUB_PATH"
         echo ====
-        .github/scripts/install-rcodesign.sh > script-output 2>&1
+        bash -x .github/scripts/install-rcodesign.sh
         echo "exit status $?"
         echo ==== after
         echo "$GITHUB_PATH"
         cat "$GITHUB_PATH"
         echo ====
-        /bin/ls -l script-output
-        cat script-output
     - name: Check New PATH
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -29,8 +29,7 @@ runs:
         DEST_DIR: ${{ inputs.install-dir }}
         VERSION: ${{ inputs.version }}
       run: |
-        bash --version
-        bash -x .github/scripts/install-rcodesign.sh
+        "${GITHUB_ACTION}/.github/scripts/install-rcodesign.sh"
         echo "exit status $?"
         echo ==== after
         echo "$GITHUB_PATH"

--- a/action.yml
+++ b/action.yml
@@ -36,10 +36,12 @@ runs:
         cat "$GITHUB_PATH"
         echo ====
         .github/scripts/install-rcodesign.sh > script-output 2>&1
+        echo "exit status $?"
         echo ==== after
         echo "$GITHUB_PATH"
         cat "$GITHUB_PATH"
         echo ====
+        /bin/ls -l script-output
         cat script-output
     - name: Check New PATH
       shell: bash

--- a/install-rcodesign.sh
+++ b/install-rcodesign.sh
@@ -6,8 +6,7 @@
 set -euo pipefail
 
 # override for testing
-#: "${DEST_DIR:="$(/bin/pwd -P)/.bob/tools"}"
-[ -n "$DEST_DIR" ] || DEST_DIR="$(/bin/pwd -P)/.bob/tools"
+: "${DEST_DIR:="$(/bin/pwd -P)/.bob/tools"}"
 : "${VERSION:=0.22.0}"
 # defaults for local testing
 : "${RUNNER_TEMP:=/tmp}"
@@ -42,7 +41,3 @@ if [[ ":$PATH:" != *":${DEST_DIR}:"* ]] ; then
     echo "Adding [$DEST_DIR] to PATH"
     echo "$DEST_DIR" >> "$GITHUB_PATH"
 fi
-
-echo mark 1
-exit 1
-echo mark 2


### PR DESCRIPTION
The primary purpose of this PR is to fix the path to the installer script so that the action works correctly when called from workflows in other repositories.

Also:
* move the script to the root of the repo, nothing gained by stuffing into `.github/scripts` -- the whole repo is the github script, really
* Don't use `$PWD` because it's not always set