### PR TITLE
Add mac support

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -12,7 +12,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: "Check workflow files"
         uses: docker://docker.mirror.hashicorp.services/rhysd/actionlint:latest
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,5 +66,5 @@ jobs:
       - name: Run Shellcheck
         uses: docker://koalaman/shellcheck:stable
         with:
-          # running the step in a container mounts the workspace as below
-          args: "/github/workspace/install-rcodesign.sh"
+          # inside the container, the working directory will be set to the mounted github workspace
+          args: "install-rcodesign.sh"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,11 +10,35 @@ permissions:
 
 jobs:
   test-install:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.target.runner }}
     strategy:
       matrix:
         dest_dir: [ '', '/tmp/rcodesign' ]
+        target:
+          - { runner: 'ubuntu-latest' }
+          - { runner: 'macos-latest' }
+          # no GH-hosted ARM64 Mac runners available yet
+          #- { runner: ['self-hosted', 'ondemand', 'macos', 'arm64'] }
     steps:
+
+      # for local act runs, install gh
+      - name: Install gh
+        if: ${{ env.ACT }}
+        env:
+          ARCHIVE: "https://github.com/cli/cli/releases/download/v2.45.0/gh_2.45.0_linux_amd64.tar.gz"
+        run: |
+          mkdir /tmp/gh
+          cd /tmp/gh
+          curl -LsSo gh.tar.gz "$ARCHIVE"
+          tar zxf gh.tar.gz
+          cp gh_*/bin/gh .
+          pwd >> "$GITHUB_PATH"
+      - name: Verify gh
+        if: ${{ env.ACT }}
+        run: |
+          which gh
+          gh --version
+
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: Install
         uses: ./

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
           which gh
           gh --version
 
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Install
         uses: ./
         with:
@@ -62,7 +62,7 @@ jobs:
   script-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Run Shellcheck
         uses: docker://koalaman/shellcheck:stable
         with:


### PR DESCRIPTION
This PR adds support for installing on MacOS.

Note that the test workflow does not currently test ARM64 Mac -- this requires a GH-hosted runner of that architecture, which is not yet supported.  (No self-hosted runners from public repos.)


Successful test [workflow](https://github.com/hashicorp/action-setup-rcodesign/actions/runs/8459122971)